### PR TITLE
Fixed script termination when an API fork compare returns '404 Not Found'

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -282,10 +282,12 @@ async function fetchMoreDir(repo, originalBranch, fork, fromOriginal, api) {
   });
   const data = await api.fetch(url, limiter);
 
-  if (fromOriginal)
-    fork.diff_from_original = printInfo('-', data, fork);
-  else
-    fork.diff_to_original = printInfo('+', data, fork);
+  if (data !== null) {
+    if (fromOriginal)
+      fork.diff_from_original = printInfo('-', data, fork);
+    else
+      fork.diff_to_original = printInfo('+', data, fork);
+  }
 }
 
 function printInfo(sep, data, fork) {
@@ -368,6 +370,8 @@ function Api(token) {
       const response = await fetch(url, newConfig);
       if (response.status === 304)
         return cached.data;
+      if (response.status === 404)
+        return null;
       if (!response.ok)
         throw Error(response.statusText);
 


### PR DESCRIPTION
When an user does not exist any longer, the API fork compare returns the HTTP error code 404 Not Found and throws an exception that terminates the comparison. This error can be reproduced by running the script for the repository "dsplaisted/strongnamer" where the listed owner "ProgrammerAndHacker" seems not to exist anymore.

This quick and dirty fix just ignores that issue. If there is a better way, I am open to suggestions.