### PR TITLE
Retrieve Auth Token from URL query string parameter 'authToken'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This project allows you to find the most active forks of a repository.
 
 I added a couple of features useful to compare forks:
-* works after providing a **personal GitHub token**. It is used only to increase the limits to query to API. The token is stored in Local Storage only, not sent anywhere except for the GitHub API.
+* works after providing a **personal GitHub token**. It is used only to increase the limits to query to API. The token is stored in Local Storage only, not sent anywhere except for the GitHub API. If the token is not stored in Local Storage, it can be provided via URL query string parameter ```authToken```.
 * include the **original repository** in the list, marked in bold
 * after expanding **Options**, it is possible to increase the **maximum amount of forks** to retrieve and to utilize some kind of caching
 * retrieve **commits of each fork** and show the differences

--- a/js/main.js
+++ b/js/main.js
@@ -11,6 +11,12 @@ window.addEventListener('load', () => {
     const token = localStorage.getItem('token');
     if (token)
       document.getElementById('token').value = token;
+    else {
+      const authToken = getQueryVariableFromUrl("authToken");
+      if (authToken) {
+        document.getElementById('token').value = authToken;
+      }
+    }
   } catch {}
 
   if (repo) {
@@ -218,6 +224,17 @@ function getRepoFromUrl() {
   const urlRepo = location.hash && location.hash.slice(1);
 
   return urlRepo && decodeURIComponent(urlRepo);
+}
+
+function getQueryVariableFromUrl(variable)
+{
+  let queryVarArray = window.location.search.substring(1).split("&");
+  for (let queryVar of queryVarArray) {
+    let kvp = queryVar.split("=");
+    if (kvp[0] == variable)
+      return kvp[1];
+  }
+  return null;
 }
 
 async function updateData(repo, originalBranch, forks, api) {


### PR DESCRIPTION
This pull-request provides functionality to retrieve the Auth Token from the URL query string parameter ```authToken``` if it is not already stored in Local Storage.

A bookmark or shortcut can contain the link to the index file including the Auth Token.
Example: ```file:///index.html?authToken=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx```

This is useful if the browser clears all stored data when closed.