### PR TITLE
Link creates new tab: don't force rescan of forks just to inspect one.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -64,7 +64,7 @@ function updateDT(data) {
   // Format dataset and redraw DataTable. Use second index for key name
   const forks = [];
   for (let fork of data) {
-    fork.repoLink = `<a href="https://github.com/${fork.full_name}">Link</a>`;
+    fork.repoLink = `<a href="https://github.com/${fork.full_name}" target="_blank" rel="noopener noreferrer">Link</a>`;
     fork.ownerName = fork.owner.login;
     forks.push(fork);
   }


### PR DESCRIPTION
Reading a long list of forks (e.g. manisandro/gImageReader) takes several minutes and uses up a lot of quota. It shouldn't be repeated unnecessarily. Change the Link anchor to access the fork in a new tab so the populated list stays that way.