### PR TITLE
Work with no token provided. (Limits data availability.)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -352,7 +352,10 @@ function Api(token) {
         authorization: "token " + token
       }
     }
-    : undefined;
+    : {
+      headers: {
+      }
+    };
 
   const rate = {
     remaining: '?',


### PR DESCRIPTION
If no token is provided (and one is often present by default!), the Javascript crashes because it is trying to parse the stringified value of config when it is set to undefined, yielding a JSON error on the letter 'u' (the first character in "undefined"). Set the default value to something harmless. (Only 60 requests per hour is allowed in that case, which is shown properly.)